### PR TITLE
Fix for extended thermostat status.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 target/
+.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>com.github.digitaldan</groupId>
 	<artifactId>jomnilink</artifactId>
 	<packaging>jar</packaging>
-	<version>1.1.0-SNAPSHOT</version>
+	<version>1.1.1-SNAPSHOT</version>
 	<name>jomnilink</name>
 	<url>https://github.com/digitaldan/jomnilink</url>
 	<description>jomnilink - A java library for connecting to HAI/Leviton Omni and Lumina home automation controllers using the HAI OmniLink II protocol.</description>

--- a/src/main/java/com/digitaldan/jomnilinkII/MessageFactory.java
+++ b/src/main/java/com/digitaldan/jomnilinkII/MessageFactory.java
@@ -421,6 +421,7 @@ public class MessageFactory {
 								.coolSetpoint(in.readUnsignedByte())
 								.mode(in.readUnsignedByte())
 								.fan(in.readUnsignedByte())
+								.hold(in.readUnsignedByte())
 								.humidity(in.readUnsignedByte())
 								.humiditySetpoint(in.readUnsignedByte())
 								.dehumidifySetpoint(in.readUnsignedByte())


### PR DESCRIPTION
Extended thermostat status is wrong.  It does not process hold status which throws off the other status as well.

