### PR TITLE
add name to thermostat properties

### DIFF
--- a/src/main/java/com/digitaldan/jomnilinkII/MessageFactory.java
+++ b/src/main/java/com/digitaldan/jomnilinkII/MessageFactory.java
@@ -621,6 +621,7 @@ public class MessageFactory {
 					.mode(mode)
 					.fan(fan)
 					.hold(hold)
+					.name(name)
                     .build();
 		}
 		case Message.OBJ_TYPE_MESG: {


### PR DESCRIPTION
Fixes defect in thermostat properties.  Name was null.